### PR TITLE
Storage Disparity Fix

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -1,5 +1,5 @@
 forge_version=1.12.2-14.23.4.2739
-mod_version=4.7.0
+mod_version=4.7.1
 minecraft_version=1.12
 group_id=com.gigabit101.quantumstorage
 mod_name=QuantumStorage

--- a/src/main/java/QuantumStorage/tiles/chests/TileChestQuantum.java
+++ b/src/main/java/QuantumStorage/tiles/chests/TileChestQuantum.java
@@ -38,7 +38,7 @@ public class TileChestQuantum extends AdvancedTileEntity
 {
     public TileChestQuantum()
     {
-        this.inv = new ItemStackHandler(192);
+        this.inv = new ItemStackHandler(182);
     }
     
     @Override


### PR DESCRIPTION
The Quantum Chest GUI shows 182 slots, but the actual tile entity has 192. This means there are 10 item slots which can be accessed via machinery and not the GUI.
The Iron, Gold, and Diamond Chests do not do this, so I assume this is unintentional.